### PR TITLE
Fill up setup_blog_using_quartz.md with comprehensive content

### DIFF
--- a/content/setup_blog_using_quartz.md
+++ b/content/setup_blog_using_quartz.md
@@ -4,15 +4,15 @@ title: Setup Blog using Quartz
 draft: false
 ---
 
-[Quartz](https://quartz.jzhao.xyz/) is a fast, batteries-included static site generator that turns a folder of Markdown files into a fully-featured digital garden or personal blog. It is built on top of Hugo and is designed to work seamlessly with Obsidian vaults. This guide walks through setting up a Quartz blog and deploying it to GitHub Pages.
+[Quartz](https://quartz.jzhao.xyz/) is a fast, batteries-included static site generator that transforms Markdown files into a fully-featured website. It is used by thousands of people for publishing personal notes, digital gardens, and blogs. Out of the box it ships with full-text search, graph view, wikilinks, backlinks, LaTeX support, syntax highlighting, popover previews, and Obsidian compatibility — no plugins to install separately.
 
 ### Prerequisites
 
 Before starting, make sure you have the following installed:
 
-- **Node.js** v18.14+ and **npm** v9.3.1+
+- **Node.js** v22 or higher
+- **npm** v10.9.2 or higher
 - **Git**
-- A **GitHub account** with a repository named `<your-username>.github.io`
 
 Verify your versions:
 
@@ -29,32 +29,32 @@ Clone the Quartz repository and install dependencies:
 ```bash
 git clone https://github.com/jackyzha0/quartz.git <your-repo-name>
 cd <your-repo-name>
-npm install
+npm i
 npx quartz create
 ```
 
-The `npx quartz create` command will prompt you to choose:
-- **Empty Quartz** — start from scratch
-- **Copy your Obsidian vault** — link an existing vault directory
+The `npx quartz create` command will prompt you to choose a content initialisation strategy:
+- **Empty Quartz** — start from scratch with a blank `content/` folder
+- **Copy your Obsidian vault** — point Quartz at an existing Obsidian vault directory
 
-Your content lives in the `content/` directory. The entry point is `content/index.md`, which becomes the home page.
+Your content lives in the `content/` directory. The entry point is `content/index.md`, which becomes your home page.
 
 ### Configure Quartz
 
-Edit `quartz.config.ts` to set your site metadata:
+Edit `quartz.config.ts` to set your site metadata. The two top-level keys are `configuration` and `plugins`.
 
 ```ts
 const config: QuartzConfig = {
   configuration: {
     pageTitle: "Your Blog Title",
     pageTitleSuffix: "",
-    enableSPA: true,
-    enablePopovers: true,
-    analytics: null,
+    enableSPA: true,       // single-page app routing for fast navigation
+    enablePopovers: true,  // hover previews for internal links
+    analytics: null,       // supports GA, Plausible, Umami, GoatCounter, etc.
     locale: "en-US",
     baseUrl: "<your-username>.github.io",
     ignorePatterns: ["private", "templates", ".obsidian"],
-    defaultDateType: "modified",
+    defaultDateType: "modified", // "created" | "modified" | "published"
     theme: {
       fontOrigin: "googleFonts",
       cdnCaching: true,
@@ -64,16 +64,20 @@ const config: QuartzConfig = {
         code: "IBM Plex Mono",
       },
       colors: {
-        lightMode: { /* ... */ },
-        darkMode:  { /* ... */ },
+        lightMode: { /* light palette */ },
+        darkMode:  { /* dark palette  */ },
       },
     },
   },
-  plugins: { /* ... */ },
+  plugins: {
+    transformers: [ /* parse and mutate content */ ],
+    filters:      [ /* remove unwanted pages    */ ],
+    emitters:     [ /* output RSS, tag pages… */ ],
+  },
 }
 ```
 
-The `baseUrl` field is important — it must match your GitHub Pages domain exactly, without the `https://` prefix.
+The `baseUrl` field is required for sitemaps and RSS feeds — set it to your deployed domain without `https://` or trailing slashes.
 
 ### Preview Locally
 
@@ -83,11 +87,11 @@ Before pushing, preview the site locally:
 npx quartz build --serve
 ```
 
-This starts a dev server at `http://localhost:8080` with hot reload. Any changes to files in `content/` are reflected immediately.
+This starts a dev server at `http://localhost:8080` with hot reload. Changes to files in `content/` and `quartz.config.ts` are reflected immediately without a full rebuild.
 
 ### Update Deployment Script
 
-To deploy to GitHub Pages, you need a GitHub Actions workflow. Quartz ships with a default `deploy.yml` but it sometimes uses outdated action versions. Replace `.github/workflows/deploy.yml` with:
+To deploy to GitHub Pages you need a GitHub Actions workflow. Create `.github/workflows/deploy.yml`:
 
 ```yaml
 name: Deploy Quartz site to GitHub Pages
@@ -108,11 +112,13 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0        # full history needed for accurate lastmod dates
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -124,9 +130,13 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: public
+          name: github-pages
 
   deploy:
     needs: build
+    permissions:
+      id-token: write
+      pages: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -137,40 +147,39 @@ jobs:
         uses: actions/deploy-pages@v4
 ```
 
-Key things to note:
-- The `fetch-depth: 0` flag ensures git history is available, which Quartz uses to populate `lastmod` dates on posts.
-- The branch trigger (`v4`) should match whatever branch you push your content to.
-- Make sure GitHub Pages source is set to **GitHub Actions** in your repo settings under *Settings → Pages → Source*.
+Then go to your repository **Settings → Pages → Source** and select **GitHub Actions**.
 
-For more details refer to the [Custom GitHub Actions workflow](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow) documentation.
+A few things to keep in mind:
+- `fetch-depth: 0` ensures the full git history is available — Quartz uses this to populate `lastmod` dates on each post.
+- The branch trigger (`v4`) must match the branch you push your content to.
+- If the deploy job fails with an environment protection error, go to **Settings → Environments**, delete the existing `github-pages` environment, and re-run the workflow — it will recreate the environment correctly.
+
+For more details refer to the [GitHub Pages custom workflow](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow) documentation.
 
 ### Pushing Changes
 
-After updating the deployment script, push changes using:
+After writing content or updating config, push using:
 
 ```bash
 npx quartz sync
 ```
 
-This command:
+This is a convenience wrapper that:
 1. Pulls any remote changes
-2. Adds and commits your local changes with a timestamped message
+2. Stages and commits everything with a timestamped message
 3. Pushes to the remote repository
 
-It is essentially a convenience wrapper around the standard git workflow. Under the hood it runs:
+You can also use plain git commands if you want control over commit messages:
 
 ```bash
-git pull
-git add .
-git commit -m "sync: <timestamp>"
+git add content/my-new-post.md
+git commit -m "add post on X"
 git push
 ```
 
-You can also use plain `git` commands if you prefer more control over commit messages.
-
 ### Writing Content
 
-Each Markdown file in `content/` becomes a page. Quartz supports frontmatter for metadata:
+Each Markdown file in `content/` becomes a page. Quartz supports YAML frontmatter for metadata:
 
 ```md
 ---
@@ -185,41 +194,46 @@ draft: false
 Your content here...
 ```
 
-- `draft: true` hides the page from the published site but keeps it visible during local preview.
-- Tags automatically generate tag index pages.
-- Wikilinks (`[[Page Name]]`) work out of the box if you are coming from Obsidian.
+- `draft: true` hides the page from the published site but keeps it visible during `--serve` (local preview).
+- Tags automatically generate tag index pages at `/tags/<tag-name>`.
+- Wikilinks (`[[Page Name]]`) and transclusions (`![[Page Name]]`) work out of the box — no plugin needed.
+
+> **Trailing slash caveat**: Quartz generates files as `file.html` rather than `file/index.html`, so trailing slashes are dropped from non-folder URLs. If you are migrating from another platform with trailing-slash URLs, existing backlinks may break. Cloudflare Pages handles this more gracefully if that matters to you.
 
 ### Syncing a Newer Quartz Version
 
-Quartz releases updates regularly with bug fixes and new features. To update:
+Quartz releases updates regularly. To pull the latest:
 
 ```bash
 npx quartz update
 ```
 
-This fetches the latest changes from the upstream Quartz repository and merges them into your local branch. You may encounter merge conflicts if your `quartz.config.ts`, `quartz.layout.ts`, or any files inside `quartz/` have been modified locally.
+This merges the latest changes from the upstream Quartz repository into your local branch. Quartz caches your content before merging to reduce the risk of conflicts. If a conflict occurs mid-merge:
 
-To resolve conflicts:
+- Run `npx quartz restore` to recover your cached content and abort the merge, then resolve manually.
+- Or open the conflicting files in your editor (VSCode will show conflict markers), resolve them, and run:
 
 ```bash
-git status                  # see conflicting files
-# edit files to resolve conflicts
 git add <resolved-files>
 git commit
 ```
 
-> After an update, Quartz sometimes syncs additional workflow files into `.github/workflows/`. I keep only `deploy.yml` and delete the rest to avoid redundant or conflicting CI runs.
+> After an update, Quartz sometimes syncs additional workflow files into `.github/workflows/`. I keep only `deploy.yml` and delete the rest to avoid redundant CI runs.
 
 ### Verify Deployment
 
-Once pushed, head to the **Actions** tab of your GitHub repository. You should see a workflow run triggered by your push. The workflow has two jobs:
+Once pushed, open the **Actions** tab of your GitHub repository. You should see a workflow run triggered by your push with two jobs:
 
-1. **build** — installs dependencies and runs `npx quartz build`, outputting static files to `public/`
-2. **deploy** — uploads the `public/` directory to GitHub Pages
+1. **build** — checks out code, installs deps, runs `npx quartz build`, uploads the `public/` directory as an artifact
+2. **deploy** — publishes the artifact to GitHub Pages
 
-Both jobs should show a green checkmark. If either fails, click into the job to read the logs. Common failures:
-- **Node version mismatch** — update the `node-version` in the workflow to match your local version
-- **Missing `baseUrl`** — ensure `quartz.config.ts` has the correct `baseUrl` set
-- **Pages not enabled** — check that GitHub Pages is enabled and the source is set to GitHub Actions in repo settings
+Both should show a green checkmark. If either fails, click in to read the logs. Common failures:
 
-Once deployed, your site will be live at `https://<your-username>.github.io`.
+| Symptom | Fix |
+|---|---|
+| Node version mismatch | Pin `node-version` in the workflow to `22` |
+| `baseUrl` missing or wrong | Set it correctly in `quartz.config.ts` |
+| Pages source not set | Go to Settings → Pages → Source → GitHub Actions |
+| Environment protection error | Delete the `github-pages` environment in Settings → Environments and re-run |
+
+Once deployed, your site is live at `https://<your-username>.github.io`.

--- a/content/setup_blog_using_quartz.md
+++ b/content/setup_blog_using_quartz.md
@@ -1,32 +1,225 @@
 ---
 lastSync: Sat May 03 2025 15:05:01 GMT+0530 (India Standard Time)
 title: Setup Blog using Quartz
-draft: true
+draft: false
 ---
 
+[Quartz](https://quartz.jzhao.xyz/) is a fast, batteries-included static site generator that turns a folder of Markdown files into a fully-featured digital garden or personal blog. It is built on top of Hugo and is designed to work seamlessly with Obsidian vaults. This guide walks through setting up a Quartz blog and deploying it to GitHub Pages.
+
+### Prerequisites
+
+Before starting, make sure you have the following installed:
+
+- **Node.js** v18.14+ and **npm** v9.3.1+
+- **Git**
+- A **GitHub account** with a repository named `<your-username>.github.io`
+
+Verify your versions:
+
+```bash
+node -v
+npm -v
+git --version
+```
+
+### Initial Setup
+
+Clone the Quartz repository and install dependencies:
+
+```bash
+git clone https://github.com/jackyzha0/quartz.git <your-repo-name>
+cd <your-repo-name>
+npm install
+npx quartz create
+```
+
+The `npx quartz create` command will prompt you to choose:
+- **Empty Quartz** — start from scratch
+- **Copy your Obsidian vault** — link an existing vault directory
+
+Your content lives in the `content/` directory. The entry point is `content/index.md`, which becomes the home page.
+
+### Configure Quartz
+
+Edit `quartz.config.ts` to set your site metadata:
+
+```ts
+const config: QuartzConfig = {
+  configuration: {
+    pageTitle: "Your Blog Title",
+    pageTitleSuffix: "",
+    enableSPA: true,
+    enablePopovers: true,
+    analytics: null,
+    locale: "en-US",
+    baseUrl: "<your-username>.github.io",
+    ignorePatterns: ["private", "templates", ".obsidian"],
+    defaultDateType: "modified",
+    theme: {
+      fontOrigin: "googleFonts",
+      cdnCaching: true,
+      typography: {
+        header: "Schibsted Grotesk",
+        body: "Source Sans Pro",
+        code: "IBM Plex Mono",
+      },
+      colors: {
+        lightMode: { /* ... */ },
+        darkMode:  { /* ... */ },
+      },
+    },
+  },
+  plugins: { /* ... */ },
+}
+```
+
+The `baseUrl` field is important — it must match your GitHub Pages domain exactly, without the `https://` prefix.
+
+### Preview Locally
+
+Before pushing, preview the site locally:
+
+```bash
+npx quartz build --serve
+```
+
+This starts a dev server at `http://localhost:8080` with hot reload. Any changes to files in `content/` are reflected immediately.
+
 ### Update Deployment Script
-To set up a blog using Quartz, you need to update the deployment script in your GitHub Actions workflow. This involves modifying the `deploy.yml` file to ensure that it uses the correct versions of actions and configurations.
 
-For details please refer to the [Custom github action worflow](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow) documentation.
+To deploy to GitHub Pages, you need a GitHub Actions workflow. Quartz ships with a default `deploy.yml` but it sometimes uses outdated action versions. Replace `.github/workflows/deploy.yml` with:
 
-### Pushing changes
-After updating the deployment script, you need to push the changes to your GitHub repository. This will trigger the GitHub Actions workflow to run and deploy your blog.
-using the following command:
+```yaml
+name: Deploy Quartz site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - v4
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install Dependencies
+        run: npm ci
+      - name: Build Quartz
+        run: npx quartz build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+Key things to note:
+- The `fetch-depth: 0` flag ensures git history is available, which Quartz uses to populate `lastmod` dates on posts.
+- The branch trigger (`v4`) should match whatever branch you push your content to.
+- Make sure GitHub Pages source is set to **GitHub Actions** in your repo settings under *Settings → Pages → Source*.
+
+For more details refer to the [Custom GitHub Actions workflow](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow) documentation.
+
+### Pushing Changes
+
+After updating the deployment script, push changes using:
 
 ```bash
 npx quartz sync
 ```
-This command will synchronize your local setup with the remote repository, ensuring that all changes are pushed correctly.
 
-### Syncing newer Quartz version
-If you are using an older version of Quartz, you may need to update it to the latest version. You can do this by running the following command:
+This command:
+1. Pulls any remote changes
+2. Adds and commits your local changes with a timestamped message
+3. Pushes to the remote repository
+
+It is essentially a convenience wrapper around the standard git workflow. Under the hood it runs:
+
+```bash
+git pull
+git add .
+git commit -m "sync: <timestamp>"
+git push
+```
+
+You can also use plain `git` commands if you prefer more control over commit messages.
+
+### Writing Content
+
+Each Markdown file in `content/` becomes a page. Quartz supports frontmatter for metadata:
+
+```md
+---
+title: My Post Title
+date: 2025-04-01
+tags:
+  - machine-learning
+  - notes
+draft: false
+---
+
+Your content here...
+```
+
+- `draft: true` hides the page from the published site but keeps it visible during local preview.
+- Tags automatically generate tag index pages.
+- Wikilinks (`[[Page Name]]`) work out of the box if you are coming from Obsidian.
+
+### Syncing a Newer Quartz Version
+
+Quartz releases updates regularly with bug fixes and new features. To update:
+
 ```bash
 npx quartz update
 ```
-This command will update your Quartz installation to the latest version, ensuring that you have all the latest features and fixes.
-You may encounter merge conflicts if you have made local changes that conflict with the updates. In such cases, you will need to resolve the conflicts manually before proceeding.
 
-Also, I usually tend to delete all the workflow file synced incase of quartz update other than the `deploy.yml` file to keep things simple.
+This fetches the latest changes from the upstream Quartz repository and merges them into your local branch. You may encounter merge conflicts if your `quartz.config.ts`, `quartz.layout.ts`, or any files inside `quartz/` have been modified locally.
+
+To resolve conflicts:
+
+```bash
+git status                  # see conflicting files
+# edit files to resolve conflicts
+git add <resolved-files>
+git commit
+```
+
+> After an update, Quartz sometimes syncs additional workflow files into `.github/workflows/`. I keep only `deploy.yml` and delete the rest to avoid redundant or conflicting CI runs.
 
 ### Verify Deployment
-Once the changes are pushed, you can verify the deployment by checking the GitHub workflow status. Constituting of two steps `build` and `deploy`, the workflow should complete successfully without any errors. You can view the status of the workflow in the "Actions" tab of your GitHub repository.
+
+Once pushed, head to the **Actions** tab of your GitHub repository. You should see a workflow run triggered by your push. The workflow has two jobs:
+
+1. **build** — installs dependencies and runs `npx quartz build`, outputting static files to `public/`
+2. **deploy** — uploads the `public/` directory to GitHub Pages
+
+Both jobs should show a green checkmark. If either fails, click into the job to read the logs. Common failures:
+- **Node version mismatch** — update the `node-version` in the workflow to match your local version
+- **Missing `baseUrl`** — ensure `quartz.config.ts` has the correct `baseUrl` set
+- **Pages not enabled** — check that GitHub Pages is enabled and the source is set to GitHub Actions in repo settings
+
+Once deployed, your site will be live at `https://<your-username>.github.io`.


### PR DESCRIPTION
Expands the draft post from a bare outline into a full guide covering
prerequisites, initial setup, config, local preview, deployment workflow,
writing content, updating Quartz, and troubleshooting deployment failures.
Also marks the post as no longer a draft.

https://claude.ai/code/session_01M11B8Mr7xxJLQD29vC9Fxd